### PR TITLE
Prevent MCMCchains from stopping when a param of interest is missing

### DIFF
--- a/R/MCMCchains.R
+++ b/R/MCMCchains.R
@@ -209,7 +209,8 @@ MCMCchains <- function(object,
 
       if (length(get_ind) < 1)
       {
-        stop(paste0('"', params[i], '"', ' not found in MCMC output.'))
+        warning(paste0('"', params[i], '"', ' not found in MCMC output.'))
+        next()
       }
       grouped <- c(grouped, get_ind)
     }
@@ -245,7 +246,6 @@ MCMCchains <- function(object,
       }
     }
   }
-
 
   #PROCESSING BLOCK
   if(coda::is.mcmc.list(object) == TRUE | typeof(object) == 'S4')

--- a/R/MCMCchains.R
+++ b/R/MCMCchains.R
@@ -145,7 +145,7 @@ MCMCchains <- function(object,
     }
     if(length(rm_ind) < 1)
     {
-      stop(paste0('"', excl, '"', ' not found in MCMC ouput.'))
+      stop(paste0('"', excl, '"', ' not found in MCMC output.'))
     }
     dups <- which(duplicated(rm_ind))
     if(length(dups) > 0)
@@ -177,7 +177,7 @@ MCMCchains <- function(object,
 
       if (length(get_ind) < 1)
       {
-        stop(paste0('"', params, '"', ' not found in MCMC ouput.'))
+        stop(paste0('"', params, '"', ' not found in MCMC output.'))
       }
       if(!is.null(excl))
       {
@@ -209,7 +209,7 @@ MCMCchains <- function(object,
 
       if (length(get_ind) < 1)
       {
-        stop(paste0('"', params[i], '"', ' not found in MCMC ouput.'))
+        stop(paste0('"', params[i], '"', ' not found in MCMC output.'))
       }
       grouped <- c(grouped, get_ind)
     }

--- a/paper/paper.md
+++ b/paper/paper.md
@@ -89,7 +89,7 @@ MCMCtrace(MCMC_data, params = 'beta\\[1\\]', ISB = FALSE, priors = PR)
 
 #### Manipulate
 
-Extract posterior chains for parameters of interest. In this way, large MCMC objects can be subset to smaller, more manageable, objects. Ouput can be in matrix format, or 'mcmc.list' format.
+Extract posterior chains for parameters of interest. In this way, large MCMC objects can be subset to smaller, more manageable, objects. Output can be in matrix format, or 'mcmc.list' format.
 
 ```{r}
 just_betas_mcmc_obj <- MCMCchains(MCMC_data, params = 'beta', mcmc.list = TRUE)


### PR DESCRIPTION
This pull request fixes `MCMCchains` from withholding output when specifying parameters of interest that are missing from the MCMC output, while others are included. If the only parameter specified is missing, it obviously does not have an output.

It also corrects a few typos.

### Current Functionality
In all examples, `mcmc.list` is a mcmc.list with 3 chains and contains parameters `b0`, `b1`, and `a0`

**Code:** `MCMCchains(mcmc.list, params=c("b0", "a0"))`
**Result:** Returns a matrix with combined chains for parameters `b0` and `a0`.

**Code:** `MCMCchains(mcmc.list, params=c("b0", "z0"))`
**Result:** Stops code with error: ` "z0" not found in MCMC output.` and does not return a value.

**Code:** `MCMCplot(mcmc.list, params=c("b0", "z0"))`
**Result:** Stops code with error: ` "z0" not found in MCMC output.` and does not create a plot.

### Problem
Automated code, or lazy scientists, can specify a list of all possible parameters to functions such as `MCMCplot` or `MCMCtrace` to gather information about those parameters of interest. However, when one of them is missing, no output is given whatsoever.

The lack of output is due to the `stop` function preventing further code execution on [this line](https://github.com/caseyyoungflesh/MCMCvis/blob/master/R/MCMCchains.R#L212):
`stop(paste0('"', params[i], '"', ' not found in MCMC ouput.'))`

### Solution
Changing the `stop` function to `warning`, and including `next()` to continue the loop will allow a returned value, while warning that the parameter is missing.

### New Functionality
**Code:** `MCMCchains(mcmc.list, params=c("b0", "z0"))`
**Result:** Gives a warning: ` "z0" not found in MCMC output.` and returns a matrix with combined chains for parameter `b0`.

Only changing the one line allows for execution halting when solitary missing parameters are specified:
**Code:** `MCMCchains(mcmc.list, params=c("z0"))`
**Result:** Stops code with error: ` "z0" not found in MCMC output.` and does not return a value.

**Code:** `MCMCplot(mcmc.list, params=c("b0", "z0"))`
**Result:** Gives a warning: ` "z0" not found in MCMC output.` and creates a MCMCplot without parameter `z0`.